### PR TITLE
Support aarch64 and PIE.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ In your own [Alire](https://alire.ada.dev) project, add ***exsytrawo*** dependen
 
 Then you can import the Ada ***exsytrawo*** package in your programs.
 
-Your program must compile with ***-g*** switch, bind with ***-E*** switch
-and link with ***-Wl,-no_pie*** switch.
+Your program must compile with ***-g*** switch and bind with ***-E*** switch.
 
 You can use it like that:
 
@@ -69,10 +68,6 @@ begin
   P2;
 end STBH;
 ```
-
-## Limitation
-
-The library is configured only for ***x86_64*** architecture.
 
 ## Licence
 

--- a/src/excep_sym_trace_workaround.adb
+++ b/src/excep_sym_trace_workaround.adb
@@ -32,9 +32,19 @@ package body Excep_Sym_Trace_Workaround is
       Ok       : Boolean;
       Ind      : Natural;
 
+      function Executable_Load_Address return System.Address;
+      pragma Import
+        (C, Executable_Load_Address,
+         "__gnat_get_executable_load_address");
+      Load_Address : constant System.Address := Executable_Load_Address;
+
       Args : GNAT.OS_Lib.Argument_List_Access :=
         GNAT.OS_Lib.Argument_String_To_List
-          ("-o " & Ada.Command_Line.Command_Name & " -arch x86_64 " &
+          ("-o " &
+           Ada.Command_Line.Command_Name &
+           (if System."/=" (Load_Address, System.Null_Address)
+            then " -l 0x" & System.Address_Image (Load_Address) & " "
+            else "") &
            Ada.Strings.Unbounded.To_String (Address_List));
    begin
       if GNAT.OS_Lib.Is_Executable_File (Exe) then


### PR DESCRIPTION
This patch corresponds to the macOS patch to System.Traceback.Symbolic which will be included in GCC 15.

Building with GCC 13.2.0-x86_64, ld warns that -no_pie is deprecated when targeting new OS versions. bin/stbga outputs
```
  stbga__p1.1 (in stbga) (stbga.adb:7)
  stbga__p2.0 (in stbga) (stbga.adb:11)
  _ada_stbga (in stbga) (stbga.adb:14)
  main (in stbga) (b__stbga.adb:248)
```

Building with GCC 14.2.0-3-aarch64, the link "warns" that **-no_pie is ignored for arm64\***.  bin/stbga outputs
```
  ada__exceptions__complete_and_propagate_occurrence (in stbga) (a-except.adb:1128)
  ada__exceptions__raise_with_location_and_msg (in stbga) (a-except.adb:1339)
  __gnat_raise_constraint_error_msg (in stbga) (a-except.adb:1083)
  __gnat_rcheck_CE_Explicit_Raise (in stbga) (a-except.adb:1400)
  stbga__p1.1 (in stbga) (stbga.adb:7)
  stbga__p2.0 (in stbga) (stbga.adb:11)
  _ada_stbga (in stbga) (stbga.adb:14)
  main (in stbga) (b__stbga.adb:245)
```

  * README.md: removed the requirement to link with -Wl,-no_pie. Removed the Limitation section.
  * src/excep_sym_trace_workaround.adb: added new function Executable_Load_Address, imported from ada_int.c. If this function returns a not-null address, add "-l <load_address>" to Args. If it returns Null_Address, don't add anything to Args. Removed the -arch x86_64 switch in Args, since atos is a universal build, and the Spawn call will run with the current executable's architecture.